### PR TITLE
Add HTTP to HTTPS redirection

### DIFF
--- a/frontend/.ebextensions/http_to_https.config
+++ b/frontend/.ebextensions/http_to_https.config
@@ -1,0 +1,12 @@
+# set ft=yaml
+files:
+  /etc/nginx/conf.d/http_to_https.conf:
+    mode: "00600"
+    owner: root
+    group: root
+    content: |
+      server {
+        listen       5000;
+        server_name  platezero.com;
+        return       301 https://platezero.com$request_uri;
+      }


### PR DESCRIPTION
Create another Nginx server which listens on port 5000 on the EC2
instance which simply returns a 301 Moved Permanently redirect to
https://platezero.com/[whatever].

The load balancer is then configured to send incoming requests on port
80 to port 5000 on the EC2 instance to serve the redirect, while HTTPS
requests coming in on port 443 continue to be directed to port 80 on the
instance to be served as normal.