### PR TITLE
Add a bottom border to plain inputs

### DIFF
--- a/frontend/components/PlainInput.tsx
+++ b/frontend/components/PlainInput.tsx
@@ -35,9 +35,13 @@ export const PlainSelect = props => (
       }
     })}
     styles={{
-      control: (base, state) => ({
+      control: base => ({
         ...base,
-        borderColor: state.isFocused ? bsLightGray : 'transparent'
+        borderStyle: 'none none solid none',
+        borderColor: bsLightGray,
+        borderRadius: 0,
+        borderWidth: '1px',
+        backgroundColor: 'transparent'
       }),
 
       // hide the indicator separator

--- a/frontend/components/Preheats.tsx
+++ b/frontend/components/Preheats.tsx
@@ -70,6 +70,16 @@ export function Preheats(props: Props) {
 
   return (
     <>
+      <ActionLine icon="fal fa-times invisible" onAction={_.noop}>
+        <Row>
+          <Col xs="12" sm="6" md="4" lg="3">
+            <strong>Device</strong>
+          </Col>
+          <Col>
+            <strong>Temperature</strong>
+          </Col>
+        </Row>
+      </ActionLine>
       {preheats.map(preheat => (
         <ActionLine
           key={preheat.id}
@@ -127,7 +137,7 @@ function Preheat({
     }
   }, [name, temp])
   return (
-    <Row className="mb-3">
+    <Row className="mb-3" noGutters>
       <Col xs="12" sm="6" md="4" lg="3">
         <PlainInput
           type="text"

--- a/frontend/style/_plain-input.scss
+++ b/frontend/style/_plain-input.scss
@@ -1,5 +1,7 @@
 .plain-input {
-  border-color: transparent;
+  border: none;
+  border-bottom: 1px solid $input-border-color;
+  border-radius: 0;
 
   &:hover {
     border-color: $input-border-color;
@@ -7,6 +9,7 @@
 
   &:focus {
     border-color: $input-border-color;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Currently, it's a little hard to tell that these are actually input
fields. This patch adds a bottom border to the PlainInput and
PlainSelect components which should help with this. An issue where the
background color of PlainSelect is being overridden to white resulting
in improper rendering of `bg-added` and `bg-changed` classes has been
fixed.

Additionally, the usage of PlainInput in the Preheats component has been
updated to be more consistent with its usage in the procedure/ingredient
sections.