### PR TITLE
Reorganize recipe layout

### DIFF
--- a/frontend/components/RecipeVersion.tsx
+++ b/frontend/components/RecipeVersion.tsx
@@ -1,70 +1,12 @@
 import React from 'react'
-import * as moment from 'moment'
 import * as ReactMarkdown from 'react-markdown'
 import { Row, Col, Badge } from 'reactstrap'
 import { Amount } from './Amount'
-import { StatBar } from './StatBar'
+import { RecipeVersionVitals } from './RecipeVersionVitals'
 import { RecipeVersionJSON } from '../models/recipe_version'
 import { IngredientLineJSON } from '../models/ingredient_line'
 import { IngredientListJSON } from '../models/ingredient_list'
 import { ProcedureListJSON } from '../models/procedure_list'
-import { get } from 'lodash'
-
-const formatDuration = (seconds: number) => {
-  const dur = moment.duration(seconds, 'seconds')
-  const [h, m] = [dur.hours(), dur.minutes()]
-  const hs = `${h}h`
-  const ms = `${m}m`
-  if (h > 0) {
-    return m !== 0 ? `${hs} ${ms}` : hs
-  }
-  return ms
-}
-
-const getStats = (v: RecipeVersionJSON) => {
-  const stats = []
-  const duration = get(v.recipeDuration, 'duration_seconds')
-  if (duration) {
-    stats.push({
-      name: 'Time',
-      icon: 'clock',
-      value: formatDuration(duration)
-    })
-  }
-  const y = get(v.recipeYield, 'text')
-  if (y) {
-    stats.push({ name: 'Yield', icon: 'utensils', value: y })
-  }
-  return stats
-}
-
-const RecipeHeader = ({
-  recipeVersion
-}: {
-  recipeVersion: RecipeVersionJSON
-}) => {
-  const stats = getStats(recipeVersion)
-  const description = get(recipeVersion, 'recipe.description')
-  const imageUrl = get(recipeVersion, 'recipe.image_url')
-  if (!stats.length && !description && !imageUrl) {
-    return null
-  }
-  return (
-    <Row>
-      <Col xs="12" lg="8" className="d-flex flex-column">
-        <StatBar stats={stats} />
-        {description && <p className="lead my-auto">{description}</p>}
-      </Col>
-      <Col xs="12" lg="4">
-        <img
-          src={imageUrl}
-          className="w-100"
-          alt={`Picture of ${recipeVersion.recipe.title}`}
-        />
-      </Col>
-    </Row>
-  )
-}
 
 const ProcedureList = ({ list }: { list: ProcedureListJSON }) => (
   <div className="mb-3">
@@ -123,20 +65,21 @@ export const RecipeVersion = (props: { recipeVersion: RecipeVersionJSON }) => {
   const v = props.recipeVersion
   return (
     <>
-      <RecipeHeader recipeVersion={v} />
-      <Row>
-        <Col className="mb-3">
-          <div className="list-inline">
-            {v.preheats.map(preheat => (
-              <div key={preheat.id} className="list-inline-item text-danger">
-                {preheat.name} {preheat.temperature} {preheat.unit}
-              </div>
-            ))}
-          </div>
-        </Col>
-      </Row>
+      <RecipeVersionVitals recipeVersion={v} />
+      {v.recipe.description && (
+        <div className="bg-light text-secondary p-5 mb-3">
+          <ReactMarkdown source={v.recipe.description} />
+        </div>
+      )}
       <Row>
         <Col xs="12" md="6" lg="4">
+          {v.recipe.image_url && (
+            <img
+              className="w-100 mb-3"
+              src={v.recipe.image_url}
+              alt={`Picture of ${v.recipe.title}`}
+            />
+          )}
           <h2>Ingredients</h2>
           {v.ingredientLists.map((il, key) => (
             <IngredientList key={key} list={il} />

--- a/frontend/components/RecipeVersionVitals.tsx
+++ b/frontend/components/RecipeVersionVitals.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import * as moment from 'moment'
+import * as _ from 'lodash'
+import * as parseUrl from 'url-parse'
+
+import { RecipeVersionJSON } from '../models'
+import { getName } from '../common/model-helpers'
+
+interface Props {
+  recipeVersion: RecipeVersionJSON
+}
+export const RecipeVersionVitals = (props: Props) => {
+  const vitals = _.flatten(
+    _.map([author, duration, recipeYield, source, preheats], visit =>
+      visit(props.recipeVersion)
+    )
+  )
+  if (!vitals.length) {
+    return null
+  }
+  return (
+    <ul className="list-inline">
+      {vitals.map((vital, idx) => (
+        <li className="list-inline-item text-muted" key={idx}>
+          {vital}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+const preheats = (rv: RecipeVersionJSON) =>
+  _.map(rv.preheats, ph => (
+    <span className="text-danger">
+      {ph.name} {ph.temperature} {ph.unit}
+    </span>
+  ))
+
+const formatDuration = (seconds: number) => {
+  const dur = moment.duration(seconds, 'seconds')
+  const [h, m] = [dur.hours(), dur.minutes()]
+  const hs = `${h}h`
+  const ms = `${m}m`
+  if (h > 0) {
+    return m !== 0 ? `${hs} ${ms}` : hs
+  }
+  return ms
+}
+
+const duration = (rv: RecipeVersionJSON) => {
+  const d = _.get(rv, 'recipeDuration.duration_seconds')
+  if (!d) {
+    return []
+  }
+  return <>Takes {formatDuration(d)}</>
+}
+
+const recipeYield = (rv: RecipeVersionJSON) => {
+  const y = _.get(rv, 'recipeYield.text')
+  if (!y) {
+    return []
+  }
+  return <>Yields {y}</>
+}
+
+const author = (rv: RecipeVersionJSON) => (
+  <>
+    By <a href={`/${rv.recipe.owner.username}`}>{getName(rv.recipe.owner)}</a>
+  </>
+)
+
+const source = (rv: RecipeVersionJSON) => {
+  const url = rv.recipe.source_url
+  if (!url) {
+    return []
+  }
+  return (
+    <>
+      Adapted from{' '}
+      <a href={url} target="_blank">
+        {parseUrl(url).hostname}
+      </a>
+    </>
+  )
+}

--- a/frontend/pages/recipe.tsx
+++ b/frontend/pages/recipe.tsx
@@ -24,7 +24,6 @@ import {
 } from '../components'
 import { RecipeJSON } from '../models/recipe'
 import { RecipeVersionJSON } from '../models/recipe_version'
-import { getName } from '../common/model-helpers'
 import {
   PlateZeroApiError,
   getRecipe,
@@ -34,7 +33,6 @@ import {
 } from '../common/http'
 import { UserContext } from '../context/UserContext'
 import { TokenContext } from '../context/TokenContext'
-import { Link } from '../routes'
 
 interface Props {
   recipe: RecipeJSON
@@ -82,12 +80,6 @@ export default class Recipe extends React.Component<Props, State> {
           <Col>
             <h1>{recipe.title}</h1>
             {recipe.subtitle && <p className="lead">{recipe.subtitle}</p>}
-            <p className="text-muted">
-              By{' '}
-              <Link route={`/${recipe.owner.username}`}>
-                <a>{getName(recipe.owner)}</a>
-              </Link>
-            </p>
           </Col>
           <Col xs="auto">
             <IfLoggedIn username={recipe.owner.username}>
@@ -248,11 +240,6 @@ const ActionMenu = ({ recipe }: { recipe: RecipeJSON }) => {
           >
             Delete Recipe&hellip;
           </DropdownItem>
-          {recipe.source_url && (
-            <DropdownItem href={recipe.source_url} target="_blank">
-              Visit Source Website
-            </DropdownItem>
-          )}
         </DropdownMenu>
       </ButtonDropdown>
       <RenameModal


### PR DESCRIPTION
Display the recipe's vital statistics (duration, preheats, yield,
author, source, etc) in an inline list near the top with the description
below and the image, if any, before the ingredients.

This addresses a few cases that looked a bit weird previously, such as
when a recipe had only an image and no description, and the image would
be smashed over to the right hand side with an empty void to its left.

Since the source URL (if present) is now available in the vital
statistics, we no longer need to show a reference to it in the Actions
menu, which is also nice because it's not really an action in the same
sense that editing the recipe is.

![Screenshot_2019-04-04 Freekeh-Stuffed Zucchini Fill 1 Created with Sketch - PlateZero](https://user-images.githubusercontent.com/654419/55568810-6d638080-56ce-11e9-82b9-1c9aa5426caa.jpg)
![Screenshot_2019-04-04 Freekeh-Stuffed Zucchini Fill 1 Created with Sketch - PlateZero](https://user-images.githubusercontent.com/654419/55568811-6d638080-56ce-11e9-972c-7e7aa602b190.png)
![Screenshot_2019-04-04 steak - PlateZero](https://user-images.githubusercontent.com/654419/55568812-6d638080-56ce-11e9-9a43-0f6256dce9a5.png)
