### PR TITLE
Stretch "see more" link

### DIFF
--- a/frontend/components/RecipeList.tsx
+++ b/frontend/components/RecipeList.tsx
@@ -96,7 +96,7 @@ const SeeMore = ({ username }: { username: string }) => (
     }}
   >
     <Link to={`/${username}/recipes`}>
-      <a className="text-secondary">See more&hellip;</a>
+      <a className="text-secondary stretched-link">See more&hellip;</a>
     </Link>
   </div>
 )


### PR DESCRIPTION
Previously, while the recipe card had stretched links, the "see more"
link did not. A "stretched link" means that you can click anywhere on
the surrounding container to follow the link. Now, you can click
anywhere on the gray box to see additional recipes just as you can click
anywhere on the title or image of a recipe to navigate to it.