### PR TITLE
Hopefully fix recipe images on Android

### DIFF
--- a/frontend/components/RecipeCard.tsx
+++ b/frontend/components/RecipeCard.tsx
@@ -10,18 +10,11 @@ export interface RecipeCardProps {
 
 export const RecipeCard = (props: RecipeCardProps) => (
   <div>
-    <div
-      className="rounded shadow-sm"
-      style={{
-        height: 180,
-        width: '100%',
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundColor: props.image_url ? 'transparent' : 'var(--primary)',
-        backgroundImage: `url(${props.image_url ||
-          '/static/recipe-placeholder-md.jpg'})`,
-        backgroundBlendMode: 'luminosity'
-      }}
+    <img
+      className="rounded"
+      style={{ height: 180, width: '100%', objectFit: 'cover' }}
+      src={props.image_url || '/static/recipe-placeholder-md.jpg'}
+      alt={props.image_url ? `Picture of ${props.title}` : 'Placeholder image'}
     />
     <div className="pt-1">
       <div className="m-0">


### PR DESCRIPTION
The Android browser seems to be choking on the recipe images. Rather
than being too tricky with the background image, use a simple <img> tag
with the `object-fit: cover` CSS property applied so as not to stretch
the images in weird ways.