### PR TITLE
Enable sign in with password manager

### DIFF
--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,21 +1,11 @@
 import * as React from 'react'
-import {
-  Alert,
-  Button,
-  Container,
-  Form,
-  FormGroup,
-  Input,
-  Label
-} from 'reactstrap'
+import { Alert, Button, Container, Form, FormGroup, Label } from 'reactstrap'
 import { authenticated, login } from '../common'
 import { Layout } from '../components'
 import Head from 'next/head'
 
 interface LoginState {
   error: string
-  password: string
-  username: string
 }
 
 const ErrorMessage = ({ err }: { err: string }) => (
@@ -23,37 +13,27 @@ const ErrorMessage = ({ err }: { err: string }) => (
 )
 
 export default class Login extends React.Component<any, LoginState> {
+  private usernameInput
+  private passwordInput
+
   constructor(props: any) {
     super(props)
-    this.state = {
-      error: '',
-      password: '',
-      username: ''
-    }
+    this.state = { error: '' }
     this.login = this.login.bind(this)
-    this.usernameChange = this.usernameChange.bind(this)
-    this.passwordChange = this.passwordChange.bind(this)
+    this.usernameInput = React.createRef()
+    this.passwordInput = React.createRef()
   }
 
   public async login(event: React.FormEvent<EventTarget>) {
     event.preventDefault()
-    const { username, password } = this.state
+    const username = this.usernameInput.current.value
+    const password = this.passwordInput.current.value
     try {
       const { user, token } = await login({ username, password })
       authenticated(user, token)
     } catch (err) {
       this.setState({ error: 'Incorrect username or password' })
     }
-  }
-
-  public usernameChange(event: React.FormEvent<HTMLInputElement>): void {
-    const username = event.currentTarget.value
-    this.setState({ username })
-  }
-
-  public passwordChange(event: React.FormEvent<HTMLInputElement>): void {
-    const password = event.currentTarget.value
-    this.setState({ password })
   }
 
   public render() {
@@ -78,37 +58,30 @@ export default class Login extends React.Component<any, LoginState> {
                     <Label for="username">
                       <strong>Username</strong>
                     </Label>
-                    <Input
+                    <input
                       type="text"
                       name="username"
-                      id="username"
+                      className="form-control"
+                      ref={this.usernameInput}
                       required
                       autoFocus={true}
                       tabIndex={1}
-                      value={this.state.username}
-                      onChange={this.usernameChange}
                     />
                   </FormGroup>
                   <FormGroup>
                     <Label for="password">
                       <strong>Password</strong>
                     </Label>
-                    <Input
+                    <input
                       type="password"
                       name="password"
-                      id="password"
+                      className="form-control"
+                      ref={this.passwordInput}
                       required
                       tabIndex={2}
-                      value={this.state.password}
-                      onChange={this.passwordChange}
                     />
                   </FormGroup>
-                  <Button
-                    type="submit"
-                    color="primary"
-                    className="btn-block"
-                    disabled={!this.state.username || !this.state.password}
-                  >
+                  <Button type="submit" color="primary" className="btn-block">
                     Sign In
                   </Button>
                 </Form>


### PR DESCRIPTION
Password managers (or at least 1Password and Pass on iOS Safari) don't
send the `change` event when they fill in the login form. As a result,
React isn't made aware of the username and password being provided and
thinks that they are still both empty strings.

To resolve this, this patch uses a slightly more primitive approach
where, when the form is submitted, we simply read the value of the
inputs and submit those values to the endpoint. Unfortunately, this
means we can't effectively conditionally disable the login button, but I
think this is a pretty acceptable compromise for being able to use a
password manager.