### PR TITLE
Fix page titles

### DIFF
--- a/frontend/pages/user-recipes.tsx
+++ b/frontend/pages/user-recipes.tsx
@@ -5,6 +5,7 @@ import nextCookie from 'next-cookies'
 import { RecipeJSON, UserJSON } from '../models'
 import { RecipeList } from '../components'
 import { getUser, getUserRecipes } from '../common/http'
+import { getName } from '../common/model-helpers'
 
 interface UserProps {
   user: UserJSON
@@ -26,9 +27,7 @@ export default class User extends React.Component<UserProps> {
     return (
       <Layout>
         <Head>
-          <title>
-            {user.username} ({user.name}) - Recipes
-          </title>
+          <title>{getName(user)} - Recipes</title>
         </Head>
         <RecipeList recipes={recipes} user={user} />
       </Layout>

--- a/frontend/pages/user.tsx
+++ b/frontend/pages/user.tsx
@@ -5,6 +5,7 @@ import nextCookie from 'next-cookies'
 import { UserJSON } from '../models/user'
 import { RecipePreview } from '../components'
 import { getUser } from '../common/http'
+import { getName } from '../common/model-helpers'
 
 interface UserProps {
   user: UserJSON
@@ -24,9 +25,7 @@ export default class User extends React.Component<UserProps> {
     return (
       <Layout>
         <Head>
-          <title>
-            {user.username} ({user.name})
-          </title>
+          <title>{getName(user)} on PlateZero</title>
         </Head>
         <ProfileHeader user={user} />
         <RecipePreview recipes={user.recipes} user={user} />


### PR DESCRIPTION
Most users don't have names filled out, so the titles previously just
had some empty parentheses.