### PR TITLE
Ensure the preheat unit is uppercased when importing

### DIFF
--- a/frontend/server/importer/html.ts
+++ b/frontend/server/importer/html.ts
@@ -111,7 +111,7 @@ export const preheats = (sel?: string) => ($: any): PreheatJSON[] => {
     preheats.push({
       name: m[1],
       temperature: parseInt(m[2]),
-      unit: m[4] || 'F' //TODO: Default to user preference?
+      unit: _.upperCase(m[4]) || 'F' //TODO: Default to user preference?
     })
   }
   return preheats


### PR DESCRIPTION
The regex (rightly) matches upper- or lower-case C or F as a unit. But
if it's lower case, when we try to save it to the database, there will
be an error. Ensure the unit is upper-cased before saving.