### PR TITLE
Add space to bottom of recipe preview

### DIFF
--- a/frontend/components/RecipePreview.tsx
+++ b/frontend/components/RecipePreview.tsx
@@ -22,7 +22,7 @@ export const RecipePreview = ({
   const not = <h2 className="m-0">{getName(user)}&#8217;s Recipes</h2>
   return (
     <section>
-      <Row className="align-items-center border-bottom pb-1">
+      <Row className="align-items-center border-bottom pb-1 mb-3">
         <Col>
           <IfLoggedIn username={user.username} else={not}>
             {me}
@@ -98,23 +98,25 @@ const RecipeCol = ({
   className?: string
   children: any
 }) => (
-  <Col xs="12" md="4" xl="3" className={`mt-3 ${className || ''}`}>
+  <Col xs="12" md="4" xl="3" className={`mb-3 ${className || ''}`}>
     {children}
   </Col>
 )
 
 const SeeMore = ({ username }: { username: string }) => (
-  <div
-    style={{
-      backgroundColor: 'var(--light)',
-      height: 180,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center'
-    }}
-  >
-    <Link to={`/${username}/recipes`}>
-      <a className="text-secondary stretched-link">See more&hellip;</a>
-    </Link>
-  </div>
+  <>
+    <div className="d-md-none">
+      <Link to={`/${username}/recipes`}>
+        <a className="btn btn-block btn-secondary">See more&hellip;</a>
+      </Link>
+    </div>
+    <div
+      className="d-none d-md-flex align-items-center justify-content-center bg-light"
+      style={{ height: 180 }}
+    >
+      <Link to={`/${username}/recipes`}>
+        <a className="text-secondary stretched-link">See more&hellip;</a>
+      </Link>
+    </div>
+  </>
 )


### PR DESCRIPTION
On small screens, the "See More" link also displays as a secondary
button. Since the user will be looking at a column view, there's no need
to take up vertical space to match the height of the other tiles, and a
button seems more natural in this context.

Fixes #85 

![Screenshot_2019-04-08 Ben on PlateZero](https://user-images.githubusercontent.com/654419/55729983-339fbc00-59e5-11e9-87fd-5f30e15bb1af.png)
![Screenshot_2019-04-08 Ben on PlateZero(1)](https://user-images.githubusercontent.com/654419/55729984-339fbc00-59e5-11e9-899e-c24cf4611bb8.png)
