### PR TITLE
Fix amount parsing

### DIFF
--- a/frontend/common/ingredient.test.ts
+++ b/frontend/common/ingredient.test.ts
@@ -60,8 +60,8 @@ test('parse 5', () => {
 test('parse 6', () => {
   expect(parse('Kosher salt and freshly ground black pepper')).toEqual({
     name: 'Kosher salt and freshly ground black pepper',
-    quantity_numerator: 1,
-    quantity_denominator: 1,
+    quantity_numerator: undefined,
+    quantity_denominator: undefined,
     preparation: undefined,
     optional: false,
     unit: undefined
@@ -81,6 +81,17 @@ test('parse 7', () => {
       'skinless chicken thighs, trimmed of excess fat (6 to 8 thighs)',
     optional: false,
     unit: 'lb'
+  })
+})
+
+test('parse 1 15-ounce', () => {
+  expect(parse('1 15-ounce can diced tomatoes')).toEqual({
+    name: '15-ounce can diced tomatoes',
+    quantity_numerator: 1,
+    quantity_denominator: 1,
+    preparation: undefined,
+    optional: false,
+    unit: undefined
   })
 })
 

--- a/frontend/server/importer/food-network.test.ts
+++ b/frontend/server/importer/food-network.test.ts
@@ -124,8 +124,8 @@ describe('Food Network importer', () => {
           },
           {
             name: 'One 19-ounce can chickpeas',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: 'drained',
             optional: false,
             unit: undefined
@@ -140,32 +140,32 @@ describe('Food Network importer', () => {
           },
           {
             name: 'Kosher salt and freshly cracked black pepper',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined
           },
           {
             name: 'Kosher salt and freshly cracked black pepper',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined
           },
           {
             name: 'Fresh cilantro sprigs',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: 'for garnish',
             optional: false,
             unit: undefined
           },
           {
             name: 'Juice of 1/2 lime',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined

--- a/frontend/server/importer/generic-html-importer.test.ts
+++ b/frontend/server/importer/generic-html-importer.test.ts
@@ -138,8 +138,8 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'pinch of cayenne pepper (optional)',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: true,
               unit: undefined
@@ -644,16 +644,16 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'For garnish:',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: false,
               unit: undefined
             },
             {
               name: 'handful chopped parsley',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: false,
               unit: undefined
@@ -771,24 +771,24 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'toppings: avocado',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: 'tomato, vegenaise, burger buns, greens',
               optional: false,
               unit: undefined
             },
             {
               name: 'skillet: 1 Tbsp oil ( extra virgin olive oil',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: 'coconut oil, or other)',
               optional: false,
               unit: undefined
             },
             {
               name: 'optional: Panko bread crumbs for crispy coating',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: true,
               unit: undefined
@@ -884,24 +884,24 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'toppings: avocado',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: 'tomato, vegenaise, burger buns, greens',
               optional: false,
               unit: undefined
             },
             {
               name: 'skillet: 1 Tbsp oil ( extra virgin olive oil',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: 'coconut oil, or other)',
               optional: false,
               unit: undefined
             },
             {
               name: 'optional: Panko bread crumbs for crispy coating',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: true,
               unit: undefined
@@ -1463,16 +1463,16 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'Maple syrup; (optional)',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: true,
               unit: undefined
             },
             {
               name: 'Fresh fruits; (optional)',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: true,
               unit: undefined
@@ -1721,16 +1721,16 @@ describe('Generic HTML import', () => {
             },
             {
               name: 'Ranch for dipping (Homemade Ranch or Whole30 Compliant)',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: undefined,
               optional: false,
               unit: undefined
             },
             {
               name: 'Parsley or green onions',
-              quantity_numerator: 1,
-              quantity_denominator: 1,
+              quantity_numerator: undefined,
+              quantity_denominator: undefined,
               preparation: 'chopped (optional)',
               optional: true,
               unit: undefined

--- a/frontend/server/importer/nyt-cooking.test.ts
+++ b/frontend/server/importer/nyt-cooking.test.ts
@@ -75,8 +75,8 @@ describe('NYT Cooking import', () => {
             name: 'Juice of 1 lemon',
             optional: false,
             preparation: undefined,
-            quantity_denominator: 1,
-            quantity_numerator: 1,
+            quantity_denominator: undefined,
+            quantity_numerator: undefined,
             unit: undefined
           },
           {

--- a/frontend/server/importer/serious-eats.test.ts
+++ b/frontend/server/importer/serious-eats.test.ts
@@ -110,8 +110,8 @@ describe('Serious Eats import', () => {
           },
           {
             name: 'Kosher salt and freshly ground black pepper',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined
@@ -180,8 +180,8 @@ describe('Serious Eats import', () => {
           },
           {
             name: 'Kosher salt and freshly ground black pepper',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined
@@ -241,8 +241,8 @@ describe('Serious Eats import', () => {
           },
           {
             name: 'Kosher salt and freshly ground black pepper',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: undefined,
             optional: false,
             unit: undefined
@@ -270,8 +270,8 @@ describe('Serious Eats import', () => {
           },
           {
             name: 'Fluffy pocketless pita bread',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation:
               'brushed in butter, lightly toasted, and cut into 1 × 3-inch strips',
             optional: false,
@@ -279,8 +279,8 @@ describe('Serious Eats import', () => {
           },
           {
             name: 'Harissa-style hot sauce',
-            quantity_numerator: 1,
-            quantity_denominator: 1,
+            quantity_numerator: undefined,
+            quantity_denominator: undefined,
             preparation: 'for serving',
             optional: false,
             unit: undefined


### PR DESCRIPTION
This patch addresses two issues with amount parsing. First, the
ingredient

  1 15-ounce can diced tomatoes

was previously not being handled correctly (the "15" was considered part
of the quantity and the fraction library doesn't know what to do with
the string "1 15"). Furthermore, when a quantity was not being found, we
were falling back to using "1" as the numerator/denominator. This leads
to unexpected results, e.g. when the recipe calls for "kosher salt", we
shouldn't translate this to "1 kosher salt".

To address these items, I've refactored the regex to be a bit more
specific in what it's looking for and introduced a matchNumber function
which separates this logic out a bit from the main ingredient parsing
function.

Furthermore, I've updated/corrected the unit tests to check for the
updated amount parsing logic.

Fixes #88