### PR TITLE
Fix editing background colors, add back placeholders

### DIFF
--- a/frontend/components/IngredientLine.tsx
+++ b/frontend/components/IngredientLine.tsx
@@ -147,67 +147,54 @@ export function IngredientLine(props: Props) {
   }
 
   return (
-    <Row noGutters={true}>
+    <Row noGutters={true} className={bgClass + ' mb-3'}>
       <Col xs="12" md="2">
-        <FormGroup>
-          <PlainInput
-            type="text"
-            placeholder="2/3…"
-            value={amount}
-            className={bgClass}
-            onChange={e => {
-              const amount = e.currentTarget.value
-              setAmount(amount)
-            }}
-          />
-        </FormGroup>
+        <PlainInput
+          type="text"
+          placeholder="e.g. 2/3"
+          value={amount}
+          onChange={e => {
+            const amount = e.currentTarget.value
+            setAmount(amount)
+          }}
+        />
       </Col>
       <Col xs="12" md="2">
-        <FormGroup>
-          <PlainSelect
-            options={Units}
-            placeholder="cup, gram…"
-            value={unit}
-            onChange={(e: any) => setUnit(e.value)}
-            className={bgClass}
-          />
-        </FormGroup>
+        <PlainSelect
+          options={Units}
+          placeholder="e.g. cup"
+          value={unit}
+          onChange={(e: any) => setUnit(e.value)}
+        />
       </Col>
       <Col xs="12" md={true}>
-        <FormGroup>
-          <PlainInput
-            type="text"
-            placeholder="onion, head of lettuce, ground black pepper…"
-            value={props.ingredient.name || ''}
-            className={bgClass}
-            onChange={e => {
-              const name = e.currentTarget.value
-              setName(name)
-            }}
-          />
-        </FormGroup>
+        <PlainInput
+          type="text"
+          placeholder="e.g. onions"
+          value={props.ingredient.name || ''}
+          onChange={e => {
+            const name = e.currentTarget.value
+            setName(name)
+          }}
+        />
       </Col>
       <Col xs="12" md="3">
-        <FormGroup>
-          <PlainInput
-            type="text"
-            placeholder="finely diced, cleaned, peeled…"
-            value={props.ingredient.preparation || ''}
-            className={bgClass}
-            onChange={e => {
-              const preparation = e.currentTarget.value
-              setPreparation(preparation)
-            }}
-          />
-        </FormGroup>
+        <PlainInput
+          type="text"
+          placeholder="e.g. diced"
+          value={props.ingredient.preparation || ''}
+          onChange={e => {
+            const preparation = e.currentTarget.value
+            setPreparation(preparation)
+          }}
+        />
       </Col>
       <Col xs="12" md="auto" className="d-flex align-items-center">
-        <FormGroup check className="mb-3">
+        <FormGroup check>
           <Label className="m-0" check>
             <Input
               type="checkbox"
               checked={!!props.ingredient.optional}
-              className={bgClass}
               onChange={e => {
                 const optional = e.currentTarget.checked
                 setOptional(optional)

--- a/frontend/components/IngredientList.tsx
+++ b/frontend/components/IngredientList.tsx
@@ -1,16 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import {
-  Button,
-  Row,
-  Col,
-  FormGroup,
-  FormText,
-  Input,
-  Label,
-  Card,
-  CardHeader,
-  CardBody
-} from 'reactstrap'
+import { Button, FormText, Input, Card, CardHeader, CardBody } from 'reactstrap'
 import * as _ from 'lodash'
 
 import { IngredientLine } from './IngredientLine'
@@ -56,8 +45,8 @@ export function IngredientList(props: Props) {
     }
   }, [name, lines])
 
-  const act = line => () => {
-    const f = line.removed ? restoreItem : removeItem
+  const act = line => {
+    const f = line.removed || isChanged(line) ? restoreItem : removeItem
     setLines(f(lines, line.id))
   }
 
@@ -78,47 +67,27 @@ export function IngredientList(props: Props) {
         )}
       </CardHeader>
       <CardBody>
-        <ActionLine icon="fal fa-times invisible" onAction={_.noop}>
-          <Row className="font-weight-bold" noGutters={true}>
-            <Col xs="auto" md="2" className="pl-3">
-              Amount
-            </Col>
-            <Col xs="auto" md="2" className="pl-3">
-              Unit
-            </Col>
-            <Col xs="auto" md={true} className="pl-3">
-              Ingredient
-            </Col>
-            <Col xs="auto" md="3" className="pl-3">
-              Preparation
-            </Col>
-            <Col xs="auto" className="invisible">
-              <FormGroup check>
-                <Label check>
-                  <Input type="checkbox" />
-                  <small>Optional</small>
-                </Label>
-              </FormGroup>
-            </Col>
-          </Row>
-        </ActionLine>
-        {lines.map(line => (
-          <ActionLine
-            icon={`fal fa-${line.removed ? 'undo' : 'times'}`}
-            key={line.id}
-            onAction={act(line)}
-          >
-            <IngredientLine
-              ingredient={line.json}
-              onChange={newLine =>
-                setLines(replaceItem(lines, line.id, newLine))
-              }
-              removed={line.removed}
-              added={line.added}
-              changed={isChanged(line)}
-            />
-          </ActionLine>
-        ))}
+        {lines.map(line => {
+          const changed = isChanged(line)
+          const icon = line.removed || changed ? 'undo' : 'times'
+          return (
+            <ActionLine
+              icon={`fal fa-${icon}`}
+              key={line.id}
+              onAction={() => act(line)}
+            >
+              <IngredientLine
+                ingredient={line.json}
+                onChange={newLine =>
+                  setLines(replaceItem(lines, line.id, newLine))
+                }
+                removed={line.removed}
+                added={line.added}
+                changed={changed}
+              />
+            </ActionLine>
+          )
+        })}
         <div>
           <Button
             color="secondary"

--- a/frontend/components/PlainInput.tsx
+++ b/frontend/components/PlainInput.tsx
@@ -45,13 +45,7 @@ export const PlainSelect = props => (
       }),
 
       // hide the indicator separator
-      indicatorSeparator: () => ({}),
-
-      // only show placeholder when focused
-      placeholder: (base, state) => ({
-        ...base,
-        opacity: state.isFocused ? 1 : 0
-      })
+      indicatorSeparator: () => ({})
     }}
   />
 )

--- a/frontend/components/Preheats.tsx
+++ b/frontend/components/Preheats.tsx
@@ -70,34 +70,28 @@ export function Preheats(props: Props) {
 
   return (
     <>
-      <ActionLine icon="fal fa-times invisible" onAction={_.noop}>
-        <Row>
-          <Col xs="12" sm="6" md="4" lg="3">
-            <strong>Device</strong>
-          </Col>
-          <Col>
-            <strong>Temperature</strong>
-          </Col>
-        </Row>
-      </ActionLine>
-      {preheats.map(preheat => (
-        <ActionLine
-          key={preheat.id}
-          icon={`fal fa-${preheat.removed ? 'undo' : 'times'}`}
-          onAction={act(preheat)}
-        >
-          {preheat.removed ? (
-            <RemovedPreheat preheat={preheat.json} />
-          ) : (
-            <Preheat
-              preheat={preheat.json}
-              onChange={json =>
-                setPreheats(replaceItem(preheats, preheat.id, json))
-              }
-            />
-          )}
-        </ActionLine>
-      ))}
+      {preheats.map(preheat => {
+        const icon = preheat.removed ? 'undo' : 'times'
+        return (
+          <ActionLine
+            key={preheat.id}
+            icon={`fal fa-${icon}`}
+            onAction={act(preheat)}
+          >
+            {preheat.removed ? (
+              <RemovedPreheat preheat={preheat.json} />
+            ) : (
+              <Preheat
+                preheat={preheat.json}
+                added={preheat.added}
+                onChange={json =>
+                  setPreheats(replaceItem(preheats, preheat.id, json))
+                }
+              />
+            )}
+          </ActionLine>
+        )
+      })}
       {addBtn}
     </>
   )
@@ -119,25 +113,32 @@ function temperatureString(preheat: PreheatJSON): string {
 
 function Preheat({
   preheat,
+  added,
   onChange
 }: {
   preheat: PreheatJSON
+  added: boolean
   onChange: (preheat: PreheatJSON) => void
 }) {
   const orig = useRef(preheat)
   const [name, setName] = useState(preheat.name || '')
   const [temp, setTemp] = useState(temperatureString(preheat))
+
+  const old = _.omit(orig.current, 'id')
+  const curr = normalize({ name, ...parseTemperature(temp) })
+  const changed = !_.isEqual(old, curr)
+
+  const bg = added ? 'bg-added' : changed ? 'bg-changed' : ''
+
   useEffect(() => {
     if (_.isFunction(onChange)) {
-      const old = _.omit(orig.current, 'id')
-      const curr = normalize({ name, ...parseTemperature(temp) })
-      const changed = !_.isEqual(old, curr)
       const id = changed ? undefined : orig.current.id
       onChange({ id, ...curr })
     }
   }, [name, temp])
+
   return (
-    <Row className="mb-3" noGutters>
+    <Row className={`mb-3 ${bg}`} noGutters>
       <Col xs="12" sm="6" md="4" lg="3">
         <PlainInput
           type="text"

--- a/frontend/components/ProcedureList.tsx
+++ b/frontend/components/ProcedureList.tsx
@@ -38,8 +38,9 @@ export function ProcedureList(props: Props) {
     }
   }, [name, lines])
 
-  const act = line => () => {
-    const f = line.removed ? restoreItem : removeItem
+  const act = line => {
+    const changed = isChanged(line)
+    const f = line.removed || changed ? restoreItem : removeItem
     setLines(f(lines, line.id))
   }
 
@@ -60,34 +61,41 @@ export function ProcedureList(props: Props) {
         )}
       </CardHeader>
       <CardBody>
-        {lines.map(line => (
-          <ActionLine
-            icon={`fal fa-${line.removed ? 'undo' : 'times'}`}
-            key={line.id}
-            onAction={act(line)}
-          >
-            {line.removed ? (
-              <div className="text-muted text-strike">{line.json.text}</div>
-            ) : (
-              <PlainInput
-                type="textarea"
-                placeholder="Step by step instructions..."
-                className={`mb-3 ${isChanged(line) ? 'bg-changed' : ''} ${
-                  line.added ? 'bg-added' : ''
-                }`}
-                value={line.json.text}
-                onChange={e =>
-                  setLines(
-                    replaceItem(lines, line.id, {
-                      id: line.json.id,
-                      text: e.target.value
-                    })
-                  )
-                }
-              />
-            )}
-          </ActionLine>
-        ))}
+        {lines.map(line => {
+          const changed = isChanged(line)
+          const icon = line.removed || changed ? 'undo' : 'times'
+          return (
+            <ActionLine
+              icon={`fal fa-${icon}`}
+              key={line.id}
+              onAction={() => act(line)}
+            >
+              {line.removed ? (
+                <div className="text-muted text-strike">{line.json.text}</div>
+              ) : (
+                <div
+                  className={`mb-3 ${isChanged(line) ? 'bg-changed' : ''} ${
+                    line.added ? 'bg-added' : ''
+                  }`}
+                >
+                  <PlainInput
+                    type="textarea"
+                    placeholder="Step by step instructions..."
+                    value={line.json.text}
+                    onChange={e =>
+                      setLines(
+                        replaceItem(lines, line.id, {
+                          id: line.json.id,
+                          text: e.target.value
+                        })
+                      )
+                    }
+                  />
+                </div>
+              )}
+            </ActionLine>
+          )
+        })}
         <div>
           <Button
             type="button"

--- a/frontend/style/_plain-input.scss
+++ b/frontend/style/_plain-input.scss
@@ -2,6 +2,7 @@
   border: none;
   border-bottom: 1px solid $input-border-color;
   border-radius: 0;
+  background-color: transparent;
 
   &:hover {
     border-color: $input-border-color;
@@ -10,14 +11,6 @@
   &:focus {
     border-color: $input-border-color;
     box-shadow: none;
+    background-color: transparent;
   }
-}
-
-.plain-input::placeholder {
-  opacity: 0;
-}
-
-.plain-input:focus::placeholder,
-.plain-input:hover::placeholder {
-  opacity: 1;
 }


### PR DESCRIPTION
Add back the placeholders even when not being hovered, now that the
borders are a little less aggressive.

Fix the added/changed background colors for the inputs (there were a few
weird behaviors such as where a changed line input was focused, the
background would go back to white).

Reintroduce the ability to reset a changed ingredient/procedure line
back to its original state by updating the `act` function to consider
whether the line has been changed, as well as setting the line icon
based on whether the line has been changed.