### PR TITLE
Remove username from navbar

### DIFF
--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -41,26 +41,8 @@ const UserCardNav = ({ user }: { user: UserJSON }) => (
     </NavItem>
     <NavItem>
       <Link route={`/${user.username}`}>
-        <a className="d-block py-1 px-2 rounded">
-          <div className="d-flex align-items-center">
-            <div className="text-white">
-              {user.name ? user.name : user.username}
-            </div>
-            <div className="ml-2">
-              <ProfilePicture img={user.avatar_url} size={30} />
-            </div>
-          </div>
-          <style jsx>
-            {`
-              a:hover {
-                text-decoration: none;
-                background-color: rgba(255, 255, 255, 0.2);
-              }
-              div {
-                letter-spacing: 0.01rem;
-              }
-            `}
-          </style>
+        <a className="d-block py-1 px-2">
+          <ProfilePicture img={user.avatar_url} size={30} />
         </a>
       </Link>
     </NavItem>


### PR DESCRIPTION
Since the username is a variable length string, it can easily lead to
weird overflow/wrapping issues when displayed along with the other items
in the navbar on small screens. One solution is to use the username in
the navbar and only display the current user's avatar to link them to
their profile page.

Fixes #86

![Screenshot_2019-04-09 Ben on PlateZero](https://user-images.githubusercontent.com/654419/55800839-9dca6680-5aa2-11e9-94d5-ae749512cbcb.png)