### PR TITLE
Be more conservative when creating recipe slugs

### DIFF
--- a/frontend/common/slug.test.ts
+++ b/frontend/common/slug.test.ts
@@ -1,0 +1,25 @@
+import { toSlug } from './slug'
+
+describe('slugification', () => {
+  it('should map unicode to an ascii aproximation', () => {
+    expect(toSlug('façile')).toBe('facile')
+  })
+
+  it('should translate characters to a meaningful equivalent', () => {
+    expect(toSlug('it was $5')).toBe('it-was-dollar5')
+  })
+
+  it('should replace non-alphanumeric characters', () => {
+    expect(toSlug('asdf!asdf')).toBe('asdf-asdf')
+    expect(toSlug('asdf*asdf')).toBe('asdf-asdf')
+    expect(toSlug('asdf.asdf')).toBe('asdf-asdf')
+  })
+
+  it('should not end or start with replacement', () => {
+    expect(toSlug('!tada!data!')).toBe('tada-data')
+  })
+
+  it('should not contain multiple replacements in sequence', () => {
+    expect(toSlug('here !/= chars')).toBe('here-chars')
+  })
+})

--- a/frontend/common/slug.ts
+++ b/frontend/common/slug.ts
@@ -1,0 +1,10 @@
+import slugify from 'slugify'
+import * as _ from 'lodash'
+
+export const toSlug = (s: string): string => {
+  const replacement = '-'
+  let slugged = slugify(s, { lower: true, remove: null, replacement })
+  slugged = _.replace(slugged, /[^a-z0-9\-]/g, replacement)
+  slugged = _.replace(slugged, /\-{2,}/g, replacement)
+  return _.trim(slugged, replacement)
+}

--- a/frontend/models/recipe.ts
+++ b/frontend/models/recipe.ts
@@ -14,7 +14,6 @@ import {
   PrimaryKey,
   Table
 } from 'sequelize-typescript'
-import slugify from 'slugify'
 import * as _ from 'lodash'
 import { PostRecipe } from '../common/request-models'
 import { User, UserJSON } from './user'
@@ -29,6 +28,7 @@ import { ProcedureList } from './procedure_list'
 import { IngredientList } from './ingredient_list'
 import { RecipeVersionIngredientList } from './recipe_version_ingredient_list'
 import { getConfig } from '../server/config'
+import { toSlug } from '../common/slug'
 
 const cfg = getConfig()
 
@@ -231,8 +231,8 @@ export class Recipe extends Model<Recipe> implements RecipeJSON {
     user_id: number,
     body: PostRecipe
   ): Promise<Recipe> {
-    const sluggd = slugify(body.title, { lower: true })
     // place an upper bound on retries to prevent DoS
+    const sluggd = toSlug(body.title)
     for (let counter = 0; counter < 100; counter++) {
       try {
         const slug = counter > 0 ? `${sluggd}-${counter}` : sluggd


### PR DESCRIPTION
The `slugify` package by default allows all sorts of undesirable
characters in its resulting slugs, e.g. dollar signs, quotes,
exclamation points. We'd really prefer that all non-/[a-z0-9\-]/ be
removed, resulting in cleaner URLs.

The new `toSlug` function in common/slug.ts wraps slugify and does some
extra transformations which are documented in the accompanying unit
tests.