### PR TITLE
Show enhanced recipe source information

### DIFF
--- a/frontend/components/RecipeVersionVitals.tsx
+++ b/frontend/components/RecipeVersionVitals.tsx
@@ -62,16 +62,52 @@ const recipeYield = (rv: RecipeVersionJSON) => {
 }
 
 const source = (rv: RecipeVersionJSON) => {
-  const url = rv.recipe.source_url
-  if (!url) {
+  const work = getWorkTitle(rv.recipe)
+  if (!work) {
     return []
   }
-  return (
-    <>
-      Adapted from{' '}
-      <a href={url} target="_blank">
-        {parseUrl(url).hostname}
-      </a>
-    </>
+  const link = getLink(rv.recipe)
+  const src = link ? (
+    <a href={link} target="_blank">
+      {' '}
+      {work}{' '}
+    </a>
+  ) : (
+    work
   )
+  return <>Adapted from {src}</>
+}
+
+// piece together the full display of the work, either "[work] by [author]", or
+// if only one of the two is provided then "[work]" or "[author]" respectively.
+// if neither is present, than we'll just get undefined.
+function getWorkTitle(recipe: RecipeJSON) {
+  const { source_url, source_title, source_author } = recipe
+  if (source_title && source_author) {
+    return `${source_title} by ${source_author}`
+  }
+  if (source_title) {
+    return source_title
+  }
+  if (source_author) {
+    return source_author
+  }
+  if (source_url) {
+    return parseUrl(source_url).hostname
+  }
+  return undefined
+}
+
+// if the recipe has a source url, return that. otherwise, if it has a source
+// isbn, return a link to a duckduckgo search for the isbn. otherwise, simply
+// return nothing
+function getLink(recipe: RecipeJSON) {
+  const { source_url, source_isbn } = recipe
+  if (source_url) {
+    return source_url
+  }
+  if (source_isbn) {
+    return `https://duck.com/?q=${encodeURIComponent('isbn ' + source_isbn)}`
+  }
+  return undefined
 }


### PR DESCRIPTION
Now that we've added some additional recipe source fields, it would be
nice to display them on the recipe page. This patch adds support for
rendering the additional source fields based on which ones are present.
I think this should do a pretty good job for just about all of the
permutations as well as not break horribly for any of them. As we go, we
may discover a few improvements we can make, however.