### PR TITLE
Hide User#email in JSON

### DIFF
--- a/frontend/models/user.ts
+++ b/frontend/models/user.ts
@@ -23,7 +23,7 @@ const cfg = getConfig()
 
 export interface UserJSON {
   avatar_url: string
-  email: string
+  email?: string
   id: number
   name: string
   recipes?: RecipeJSON[]
@@ -53,7 +53,13 @@ export class User extends Model<User> implements UserJSON {
   @Unique
   @IsEmail
   @Column
-  public email: string
+  public set email(value: string) {
+    this.setDataValue('email', value)
+  }
+
+  public get email() {
+    return undefined
+  }
 
   @Column
   public set password_hash(value: string) {
@@ -69,7 +75,7 @@ export class User extends Model<User> implements UserJSON {
     const dv = this.getDataValue('avatar_url')
     if (!dv) {
       const emailHash = crypto.createHash('md5')
-      emailHash.update(this.email.toLowerCase())
+      emailHash.update(this.getDataValue('email').toLowerCase())
       const hex = emailHash.digest('hex')
       return `https://www.gravatar.com/avatar/${hex}`
     }


### PR DESCRIPTION
Currently, someone could browse to /api/users and get a list of all of
the email addresses that have been used to sign up for PZ. This isn't
great. We aren't really using the email addresses anywhere, so for now
we'll just hide them the same way we do the password hashes. I'm sure
once we start building out a profile page sort of thing, we'll need to
revisit this so that users can see/update their email address. I think
there may be some interesting things we can do with sequelize Scopes,
though I haven't dug into the docs for that quite enough to know for
sure, much less what exactly we'd want to do.