### PR TITLE
Make cookies expire after 365 days

### DIFF
--- a/frontend/common/auth.ts
+++ b/frontend/common/auth.ts
@@ -9,7 +9,11 @@ export interface Authentication {
 }
 
 export const authenticated = async (token: string, refresh: string) => {
-  cookie.set('auth', JSON.stringify({ token, refresh }))
+  cookie.set('auth', JSON.stringify({ token, refresh }), {
+    expires: 365,
+    secure: true,
+    samesite: 'strict'
+  } as any)
 }
 
 export const getAuth = (ctx: any = undefined): Authentication => {


### PR DESCRIPTION
Previously, by not defining an expiration time for the auth cookie, its
lifetime was implicitly only the current browser session. A year seems
like a sane default for the refresh cookie, especially as it will be
re-set each time the token is refreshed. So in practice, this means that
a user could log in to PZ, wait a year, visit the site again, and still
be logged in the next day (as they would have a new cookie set with
their new auth token).

While we're at it, I've added the `secure` and `samesite` properties to
the auth cookie. Secure means that an encrypted channel is required to
send the cookie; if for some reason the user visits platezero over an
unencrypted connection, the cookie will not be sent. This might be the
case e.g. if they simply type platezero.com into their browser which
might first try a plain http connection before trying a TLS one. The
samesite property instructs the browser only to send this cookie to the
platezero.com domain. The samesite property instructs the browser to
only send the cookie to the platezero.com domain and not with any
cross-origin requests, such as those which are currently being made for
images in a bunch of places.

Unfortunately, the Typescript definitions don't seem to have been
updated along with js-cookie's v2.2.0 release when custom properties
were enabled so we need to use `as any` to get Typescript to stop
yelling. The reason samesite isn't included in the library is that the
samesite property is still not technically a part of RFC 6265 despite
its ubiquitous browser implementation.