### PR TITLE
Add Images to RecipeList

### DIFF
--- a/frontend/components/RecipeList.tsx
+++ b/frontend/components/RecipeList.tsx
@@ -56,7 +56,7 @@ export const RecipeList = ({ children, recipes, user }: RecipesProps) => {
                 <Col
                   xs={recipe.image_url ? '10' : '12'}
                   md={recipe.image_url ? '11' : '12'}
-                  className="pr-0"
+                  className={recipe.image_url ? 'pr-0' : 'px-0'}
                 >
                   <div>
                     <strong>{recipe.title}</strong>


### PR DESCRIPTION
If present, an image is presented on the left side of the ListGroupItem.
The list has also been made flush, which looks cleaner on small screens.

Resolve #145

![image](https://user-images.githubusercontent.com/166767/56933419-bfbd7480-6ab5-11e9-907b-d1087a1f465b.png)

![image](https://user-images.githubusercontent.com/166767/56933613-a36e0780-6ab6-11e9-8a68-7d39053ba6ba.png)

