### PR TITLE
Add metrics

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "node-sass": "4.11.0",
     "nodemon": "1.18.11",
     "pg": "7.9.0",
+    "prom-client": "11.3.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-dropzone": "10.1.3",

--- a/frontend/server/api/index.ts
+++ b/frontend/server/api/index.ts
@@ -1,6 +1,7 @@
 import * as express from 'express'
 import * as _ from 'lodash'
 import * as jwtMiddleware from 'express-jwt'
+import * as prom from 'prom-client'
 import { users } from './users'
 import { user } from './user'
 import { User } from '../../models/user'
@@ -70,7 +71,12 @@ r.get('/', (_, res) => {
 })
 
 // login route
+const loginAttemptCounter = new prom.Counter({
+  name: 'pz_api_login_attempts',
+  help: 'Login attempts'
+})
 r.post('/login', async (req, res) => {
+  loginAttemptCounter.inc()
   const { username, password } = req.body
   if (!username || !password) {
     return badRequest(res, 'username and password are required')

--- a/frontend/server/index.ts
+++ b/frontend/server/index.ts
@@ -1,23 +1,55 @@
 import * as express from 'express'
 import * as next from 'next'
 import { join } from 'path'
+import * as prom from 'prom-client'
 const { routes } = require('../routes')
 const { sequelize } = require('../models')
 import { api } from './api'
 import { config } from './config'
+import { HttpStatus } from '../common/http-status'
 
 const app = next({ dev: config.dev })
 const handler = routes.getRequestHandler(app)
 
 app.prepare().then(() => {
+  prom.collectDefaultMetrics({ timeout: 5000 })
+
   const server = express()
 
   server.use(express.static(join(__dirname, '..', 'static')))
-  server.use('/api', api)
+
+  const apiLatency = new prom.Histogram({
+    name: 'pz_api_latency',
+    help: 'API latency',
+    labelNames: ['method', 'code']
+  })
+  server.use(
+    '/api',
+    (req, res, next) => {
+      const finish = apiLatency.startTimer({ method: req.method })
+      res.on('finish', () => {
+        finish({ code: res.statusCode })
+      })
+      next()
+    },
+    api
+  )
+
   server.use(
     '/announcements',
     express.static(join(__dirname, '..', 'announcements'))
   )
+  server.get('/_metrics', (req, res) => {
+    const auth = req.headers.authorization
+    if (!auth) {
+      return res.status(HttpStatus.Unauthorized).end()
+    }
+    const [scheme, token] = auth.split(' ')
+    if (!scheme || token !== 'eereexisahJeishiehahqu7eitei5eis') {
+      return res.status(HttpStatus.Unauthorized).end()
+    }
+    return res.end(prom.register.metrics())
+  })
   server.use(handler)
 
   sequelize

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2166,6 +2166,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+  integrity sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ=
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -7275,6 +7280,13 @@ progress@2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+prom-client@11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-11.3.0.tgz#fe93f360182f1ec1921722efc211a6c0e68e0253"
+  integrity sha512-OqSf5WOvpGZXkfqPXUHNHpjrbEE/q8jxjktO0i7zg1cnULAtf0ET67/J5R4e4iA4MZx2260tzTzSFSWgMdTZmQ==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -8793,6 +8805,13 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  integrity sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=
+  dependencies:
+    bintrees "1.0.1"
 
 term-size@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Start a framework which lets us easily collect metrics from our prod
instances using prometheus.

There is a new endpoint, /_metrics, which can be used to scrape the
current values. Right now, we're just collecting very baseline
information. I'd like to get this up and running so that we can easily
instrument both business and technical metrics that we're interested in.
For now, simply measuring API requests will give us an idea of how much
PZ is being used. In the near future, we can add things like tracking
new users signing up, loading particular pages we're interested in (such
as the recipe view page), etc.

Once this is live, my next step will be to set up a dashboard that
scrapes metrics from the new endpoint and lets us look at them on a
Grafana dashboard.