### PR TITLE
Fix duplicate slug error handling

### DIFF
--- a/frontend/models/recipe.ts
+++ b/frontend/models/recipe.ts
@@ -50,7 +50,7 @@ const isUniqueSlugError = (e): boolean => {
   return Boolean(
     e.name == 'SequelizeUniqueConstraintError' &&
       e.fields['user_id'] &&
-      e.fields['slug']
+      e.fields['lower(slug::text)']
   )
 }
 


### PR DESCRIPTION
The slug is now checked as a lower case string, which caused the
validation error field to change the signature of the fields.

Fix #200