### PR TITLE
Update instrumentation

### DIFF
--- a/frontend/server/api/index.ts
+++ b/frontend/server/api/index.ts
@@ -1,7 +1,6 @@
 import * as express from 'express'
 import * as _ from 'lodash'
 import * as jwtMiddleware from 'express-jwt'
-import * as prom from 'prom-client'
 import { users } from './users'
 import { user } from './user'
 import { User } from '../../models/user'
@@ -63,7 +62,7 @@ r.use(
 )
 
 // the index route. provide some useful URLs
-r.get('/', (_, res) => {
+r.get('/', function apiIndex(_, res) {
   return res.json({
     users_url: `${config.apiUrl}/users`,
     current_user_url: `${config.apiUrl}/user`
@@ -71,12 +70,7 @@ r.get('/', (_, res) => {
 })
 
 // login route
-const loginAttemptCounter = new prom.Counter({
-  name: 'pz_api_login_attempts',
-  help: 'Login attempts'
-})
-r.post('/login', async (req, res) => {
-  loginAttemptCounter.inc()
+r.post('/login', async function login(req, res) {
   const { username, password } = req.body
   if (!username || !password) {
     return badRequest(res, 'username and password are required')
@@ -104,7 +98,7 @@ r.post('/login', async (req, res) => {
 })
 
 // refresh JWT
-r.post('/login/refresh', async (req, res) => {
+r.post('/login/refresh', async function getRefreshToken(req, res) {
   const { token } = req.body
   if (!token) {
     return badRequest(res, '`token` is required')

--- a/frontend/server/api/search.ts
+++ b/frontend/server/api/search.ts
@@ -25,7 +25,7 @@ export const searchQuery = (q?: string, user_id?: number) => {
   }
 }
 
-r.get('/', async (req, res) => {
+r.get('/', async function search(req, res) {
   const { q, user_id } = req.query
   try {
     const results = await Recipe.findAll(searchQuery(q, user_id))

--- a/frontend/server/api/user.ts
+++ b/frontend/server/api/user.ts
@@ -29,7 +29,7 @@ export interface AuthenticatedRequest extends Request {
 
 const r = express.Router()
 
-r.get('/', async (req: AuthenticatedRequest, res) => {
+r.get('/', async function getCurrentUser(req: AuthenticatedRequest, res) {
   try {
     const user = await User.findOne({ where: { username: req.user.username } })
     return res.json(user)
@@ -38,7 +38,10 @@ r.get('/', async (req: AuthenticatedRequest, res) => {
   }
 })
 
-r.put('/', validateUserPatch, async (req: AuthenticatedRequest, res) => {
+r.put('/', validateUserPatch, async function updateUser(
+  req: AuthenticatedRequest,
+  res
+) {
   try {
     const user = await User.findByUsername(req.user.username)
     await user.update(req.body)
@@ -48,7 +51,10 @@ r.put('/', validateUserPatch, async (req: AuthenticatedRequest, res) => {
   }
 })
 
-r.post('/recipe', validateNewRecipe, async (req: AuthenticatedRequest, res) => {
+r.post('/recipe', validateNewRecipe, async function createRecipe(
+  req: AuthenticatedRequest,
+  res
+) {
   try {
     return res
       .status(HttpStatus.Created)
@@ -58,30 +64,29 @@ r.post('/recipe', validateNewRecipe, async (req: AuthenticatedRequest, res) => {
   }
 })
 
-r.patch(
-  '/recipes/:slug',
-  validateRecipePatch,
-  async (req: AuthenticatedRequest, res) => {
-    try {
-      const { slug } = req.params
-      const recipe = await Recipe.findOne({
-        where: { user_id: req.user.userId, slug }
-      })
-      if (!recipe) {
-        return notFound(res)
-      }
-      await recipe.update(req.body)
-      return res.json(recipe)
-    } catch (err) {
-      return internalServerError(res, err)
+r.patch('/recipes/:slug', validateRecipePatch, async function updateRecipe(
+  req: AuthenticatedRequest,
+  res
+) {
+  try {
+    const { slug } = req.params
+    const recipe = await Recipe.findOne({
+      where: { user_id: req.user.userId, slug }
+    })
+    if (!recipe) {
+      return notFound(res)
     }
+    await recipe.update(req.body)
+    return res.json(recipe)
+  } catch (err) {
+    return internalServerError(res, err)
   }
-)
+})
 
 r.patch(
   '/recipes/:slug/branches/:branch',
   validateRecipeVersionPatch,
-  async (req: AuthenticatedRequest, res) => {
+  async function updateRecipeVersion(req: AuthenticatedRequest, res) {
     try {
       const { slug, branch } = req.params
       const recipe = await Recipe.findOne({
@@ -105,7 +110,10 @@ r.patch(
   }
 )
 
-r.delete('/recipes/:slug', async (req: AuthenticatedRequest, res) => {
+r.delete('/recipes/:slug', async function deleteRecipe(
+  req: AuthenticatedRequest,
+  res
+) {
   try {
     const { slug } = req.params
     const recipe = await Recipe.findOne({
@@ -151,7 +159,10 @@ const upload = multer({
   })
 })
 
-r.post('/images', upload.single('file'), async (req: any, res) => {
+r.post('/images', upload.single('file'), async function uploadPublicImage(
+  req: any,
+  res
+) {
   res.status(HttpStatus.Created).json({
     url: `https://static.platezero.com/${req.pzUploadKey}`
   })

--- a/frontend/server/api/users/index.ts
+++ b/frontend/server/api/users/index.ts
@@ -17,7 +17,7 @@ const isUniqueEmailError = (err: any) =>
   'unique violation' === _.get(err, 'errors[0].type', '') &&
   'email' === _.get(err, 'errors[0].path', '')
 
-r.get('/', async (_, res) => {
+r.get('/', async function getUsers(_, res) {
   try {
     const users = await User.findAll({ order: [['id', 'DESC']] })
     return res.json(users)
@@ -26,7 +26,7 @@ r.get('/', async (_, res) => {
   }
 })
 
-r.post('/', validateNewUser, async (req, res) => {
+r.post('/', validateNewUser, async function createUser(req, res) {
   const { username, password, email } = req.body
   const u = User.build({ username, email })
   try {
@@ -53,7 +53,7 @@ r.post('/', validateNewUser, async (req, res) => {
 
 r.use(
   '/:username',
-  async (req, res, next) => {
+  async function populateUsername(req, res, next) {
     const { username } = req.params
     try {
       const user = await User.findByUsername(username)

--- a/frontend/server/api/users/user/index.ts
+++ b/frontend/server/api/users/user/index.ts
@@ -13,7 +13,7 @@ export interface UserRequest extends Request {
   user: User
 }
 
-r.get('/', async (req: UserRequest, res) => {
+r.get('/', async function getUser(req: UserRequest, res) {
   try {
     const recipes = await Recipe.findAll({
       where: { user_id: req.user.id },
@@ -31,7 +31,7 @@ r.get('/', async (req: UserRequest, res) => {
   }
 })
 
-r.get('/recipes', async (req: UserRequest, res) => {
+r.get('/recipes', async function getUserRecipes(req: UserRequest, res) {
   const { q } = req.query
   return res.json(
     await Recipe.findAll({
@@ -43,7 +43,7 @@ r.get('/recipes', async (req: UserRequest, res) => {
 
 r.use(
   '/recipes/:slug',
-  async (req: UserRequest, res, next) => {
+  async function populateRecipe(req: UserRequest, res, next) {
     const { slug } = req.params
     try {
       const recipe = await Recipe.findOne({

--- a/frontend/server/api/users/user/recipe.ts
+++ b/frontend/server/api/users/user/recipe.ts
@@ -22,7 +22,7 @@ export interface RecipeRequest extends Request {
   recipe: Recipe
 }
 
-r.get('/', async (req: RecipeRequest, res) => {
+r.get('/', async function getRecipe(req: RecipeRequest, res) {
   res.json(
     await req.recipe.reload({
       include: [
@@ -36,7 +36,7 @@ r.get('/', async (req: RecipeRequest, res) => {
   )
 })
 
-r.get('/versions', async (req: RecipeRequest, res) => {
+r.get('/versions', async function getRecipeVersions(req: RecipeRequest, res) {
   try {
     return res.json(
       await RecipeVersion.findAll({
@@ -50,7 +50,10 @@ r.get('/versions', async (req: RecipeRequest, res) => {
   }
 })
 
-r.get('/versions/:id', async (req: RecipeRequest, res) => {
+r.get('/versions/:id', async function getRecipeVersion(
+  req: RecipeRequest,
+  res
+) {
   const id = parseInt(req.params.id, 10)
   const l = RecipeVersion.sequelize.literal
   try {

--- a/frontend/server/errors.ts
+++ b/frontend/server/errors.ts
@@ -42,7 +42,7 @@ export const notFound = (res: Response) =>
   res.status(HttpStatus.NotFound).json({ errors: ['not found'] })
 
 // HTTP 500 Internal Server Error
-export const internalServerError = (res: Response, error?: any) => {
+export const internalServerError = (res: Response, error: any) => {
   console.error(error || 'internal server error')
   return res
     .status(HttpStatus.InternalServerError)


### PR DESCRIPTION
This patch adjusts our initial instrumentation to hopefully be a bit
more helpful. The Prometheus metrics have been moved from the API router
to be an app-level middleware so that we capture all HTTP requests.
Also, the metrics have been renamed to use the Prometheus-recommended
naming scheme.

A "handler" label has been added so that we can more easily identify
problematic or frequently used handler functions. This name is taken
from the actual function name which is used to handle the request, so
all of the API handler functions have been changed from anonymous
functions to named functions, which enables this tracking.

The importer now collects a few additional metrics as well: for website
imports, we have a counter labelled by hostname so we can see which
sites we are predominantly importing from. The file importer now tracks
number of files in each upload as well as the size of each file. These
metrics are labelled by MIME type, again so that we can see what sorts
of imports are most popular.