### PR TITLE
Warning message in case iframe doesn't load

### DIFF
--- a/frontend/pages/new-recipe-url.tsx
+++ b/frontend/pages/new-recipe-url.tsx
@@ -56,7 +56,7 @@ const NotShowing = ({ href }) => {
         </a>{' '}
         to open the site in a new tab and copy from there.
       </p>
-      <Button color="link" className="" onClick={() => setShow(false)}>
+      <Button color="link" onClick={() => setShow(false)}>
         <i className="fal fa-times-circle" />
       </Button>
     </div>


### PR DESCRIPTION
iFrame loading cannot easily be detected, so show a warning no matter
what with an option to dismiss it.

![image](https://user-images.githubusercontent.com/166767/57251243-5b4f6780-7017-11e9-9017-5ceabd73a473.png)