### PR TITLE
Transform recipe page image to 99% of its size

### DIFF
--- a/frontend/components/RecipeVersionVitals.tsx
+++ b/frontend/components/RecipeVersionVitals.tsx
@@ -59,7 +59,7 @@ const RecipeVersionHeaderImage = ({
           alt={`Picture of ${title}`}
           style={{ objectFit: 'cover' }}
           src={imageUrl}
-          proxy=".99"
+          proxy="r360"
         />
         <div
           className="position-absolute text-white w-100 p-2 pt-5"


### PR DESCRIPTION
EXIF data is lost in the transform of any image that we proxy since
writing it back out to the file is [non-trivial][1]. Therefore, when any
transform is applied to an image the EXIF data is examined and rotations
are applied so the resulting image is presented in its "preferred
orientation".

When requesting the big beautiful recipe page image, request an image
that is 1% smaller to transform the image. This ensures EXIF data is
applied and the resulting image will always be the correct orientation.

Fix #258

See: 
* https://github.com/willnorris/imageproxy/issues/63
* https://github.com/willnorris/imageproxy/commit/67619a67ae673cd81dcef6f878a6b131db70b948

[1]: https://github.com/willnorris/imageproxy/issues/63#issuecomment-216418269