### PR TITLE
Use the auto-resizing textarea component everywhere

### DIFF
--- a/frontend/components/AddNote.tsx
+++ b/frontend/components/AddNote.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { FormGroup, Label, Input, FormText, Button } from 'reactstrap'
+import TextareaAutosize from 'react-textarea-autosize'
 import { api, getErrorMessages } from '../common/http'
 import { AlertErrors } from './AlertErrors'
 import { NoteJSON } from '../models'
@@ -44,8 +45,9 @@ export const AddNote = ({
   return (
     <form onSubmit={createNote}>
       <FormGroup>
-        <Input
-          type="textarea"
+        <TextareaAutosize
+          minRows={3}
+          className="form-control"
           value={text}
           onChange={e => setText(e.target.value)}
           disabled={isWorking}

--- a/frontend/components/LivePreviewEditor.tsx
+++ b/frontend/components/LivePreviewEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react'
 import * as _ from 'lodash'
-import { Row, Col, Input } from 'reactstrap'
+import { Row, Col } from 'reactstrap'
+import TextareaAutosize from 'react-textarea-autosize'
 
 interface Props<T> {
   initialData: T
@@ -43,8 +44,8 @@ export function LivePreviewEditor<T>(props: Props<T>) {
     <Row>
       <Col xs="12" sm="6">
         <div style={{ position: 'relative' }}>
-          <Input
-            type="textarea"
+          <TextareaAutosize
+            className="form-control"
             style={{
               minHeight: props.minHeight,
               backgroundColor: 'transparent'

--- a/frontend/components/RecipeNav.tsx
+++ b/frontend/components/RecipeNav.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useContext } from 'react'
+import TextareaAutosize from 'react-textarea-autosize'
 import Router from 'next/router'
 import { get } from 'lodash'
 import {
@@ -220,8 +221,8 @@ const RenameModal = ({
         </FormGroup>
         <FormGroup>
           <Label>Description</Label>
-          <Input
-            type="textarea"
+          <TextareaAutosize
+            className="form-control"
             value={description}
             onChange={e => setDescription(e.target.value)}
           />

--- a/frontend/pages/edit-recipe.tsx
+++ b/frontend/pages/edit-recipe.tsx
@@ -10,10 +10,10 @@ import {
   Row,
   Col,
   Button,
-  Input,
   FormGroup,
   FormText
 } from 'reactstrap'
+import TextareaAutosize from 'react-textarea-autosize'
 
 import {
   AlertErrors,
@@ -199,8 +199,9 @@ export default class EditRecipe extends React.Component<Props, State> {
             <Row>
               <Col>
                 <FormGroup>
-                  <Input
-                    type="textarea"
+                  <TextareaAutosize
+                    minRows={3}
+                    className="form-control"
                     value={this.state.message}
                     placeholder="e.g. Remove crushed red pepper to make it less spicy"
                     onChange={e => this.setState({ message: e.target.value })}


### PR DESCRIPTION
We use textareas a bunch of places for user input. The notes PR
introduced a new TextareaAutosize component (from an external library).
Now, everywhere that we previously used a <textarea>, use
<TextareaAutosize>.