### PR TITLE
Add full-text recipe search

### DIFF
--- a/db/migrate/04_recipe_search.sql
+++ b/db/migrate/04_recipe_search.sql
@@ -1,0 +1,35 @@
+CREATE VIEW recipe_search_documents AS
+  WITH rv_corpus AS (
+    SELECT
+      recipe_id,
+      COALESCE(string_agg(ingredient_lines.name, ' ')) AS corpus
+    FROM
+      recipe_versions
+    JOIN recipe_version_ingredient_lists ON recipe_version_ingredient_lists.recipe_version_id = recipe_versions.id
+    JOIN ingredient_list_lines ON ingredient_list_lines.ingredient_list_id = recipe_version_ingredient_lists.ingredient_list_id
+    JOIN ingredient_lines ON ingredient_lines.id = ingredient_list_lines.ingredient_line_id
+    WHERE recipe_version_id IN (SELECT recipe_version_id FROM recipe_branches)
+    GROUP BY recipe_id
+    UNION
+    SELECT
+      recipe_id,
+      COALESCE(string_agg(procedure_lines.text, ' ')) AS corpus
+    FROM
+      recipe_versions
+    JOIN recipe_version_procedure_lists ON recipe_version_procedure_lists.recipe_version_id = recipe_versions.id
+    JOIN procedure_list_lines ON procedure_list_lines.procedure_list_id = recipe_version_procedure_lists.procedure_list_id
+    JOIN procedure_lines ON procedure_lines.id = procedure_list_lines.procedure_line_id
+    WHERE recipe_version_id IN (SELECT recipe_version_id FROM recipe_branches)
+    GROUP BY recipe_id
+  )
+  SELECT
+    recipes.id AS recipe_id,
+    recipes.user_id AS user_id,
+    setweight(to_tsvector(unaccent(COALESCE(recipes.title, ''))), 'A') ||
+    setweight(to_tsvector(unaccent(COALESCE(recipes.description, ''))), 'B') ||
+    setweight(to_tsvector(unaccent(string_agg(rv_corpus.corpus, ' '))), 'C') AS doc
+  FROM
+    rv_corpus
+  JOIN recipes ON recipes.id = rv_corpus.recipe_id
+  WHERE recipes.deleted_at IS NULL
+  GROUP BY recipes.id, recipes.user_id;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION unaccent;
+
 CREATE TABLE ingredient_lines (
     id SERIAL PRIMARY KEY,
     name character varying NOT NULL,
@@ -156,6 +158,42 @@ CREATE TABLE refresh_tokens (
   updated_at timestamp without time zone DEFAULT now(),
   deleted_at timestamp without time zone
 );
+
+CREATE VIEW recipe_search_documents AS
+  WITH rv_corpus AS (
+    SELECT
+      recipe_id,
+      COALESCE(string_agg(ingredient_lines.name, ' ')) AS corpus
+    FROM
+      recipe_versions
+    JOIN recipe_version_ingredient_lists ON recipe_version_ingredient_lists.recipe_version_id = recipe_versions.id
+    JOIN ingredient_list_lines ON ingredient_list_lines.ingredient_list_id = recipe_version_ingredient_lists.ingredient_list_id
+    JOIN ingredient_lines ON ingredient_lines.id = ingredient_list_lines.ingredient_line_id
+    WHERE recipe_version_id IN (SELECT recipe_version_id FROM recipe_branches)
+    GROUP BY recipe_id
+    UNION
+    SELECT
+      recipe_id,
+      COALESCE(string_agg(procedure_lines.text, ' ')) AS corpus
+    FROM
+      recipe_versions
+    JOIN recipe_version_procedure_lists ON recipe_version_procedure_lists.recipe_version_id = recipe_versions.id
+    JOIN procedure_list_lines ON procedure_list_lines.procedure_list_id = recipe_version_procedure_lists.procedure_list_id
+    JOIN procedure_lines ON procedure_lines.id = procedure_list_lines.procedure_line_id
+    WHERE recipe_version_id IN (SELECT recipe_version_id FROM recipe_branches)
+    GROUP BY recipe_id
+  )
+  SELECT
+    recipes.id AS recipe_id,
+    recipes.user_id AS user_id,
+    setweight(to_tsvector(unaccent(COALESCE(recipes.title, ''))), 'A') ||
+    setweight(to_tsvector(unaccent(COALESCE(recipes.description, ''))), 'B') ||
+    setweight(to_tsvector(unaccent(string_agg(rv_corpus.corpus, ' '))), 'C') AS doc
+  FROM
+    rv_corpus
+  JOIN recipes ON recipes.id = rv_corpus.recipe_id
+  WHERE recipes.deleted_at IS NULL
+  GROUP BY recipes.id, recipes.user_id;
 
 -- foreign keys
 ALTER TABLE ingredient_list_lines ADD FOREIGN KEY (ingredient_line_id) REFERENCES ingredient_lines (id);

--- a/frontend/common/http.ts
+++ b/frontend/common/http.ts
@@ -2,7 +2,13 @@ import 'isomorphic-fetch'
 import getConfig from 'next/config'
 import * as _ from 'lodash'
 import { stringify } from 'query-string'
-import { UserJSON, RecipeJSON, RecipeVersionJSON, NoteJSON } from '../models'
+import {
+  UserJSON,
+  RecipeJSON,
+  RecipeVersionJSON,
+  NoteJSON,
+  RecipeSearchDocumentJSON
+} from '../models'
 import { PostRecipe, RecipeVersionPatch, NotePatch } from './request-models'
 import { HttpStatus } from './http-status'
 import { get } from 'lodash'
@@ -142,15 +148,30 @@ class Api {
 
   getUserRecipes = (
     username: string,
-    q?: string,
     sort?: string,
     opts: RequestInit = {}
   ) => {
-    const query = stringify({ q, sort })
+    const query = stringify({ sort })
     return this._fetch<RecipeJSON[]>(
       `/users/${username}/recipes${query ? '?' + query : ''}`,
       opts
     )
+  }
+
+  searchUserRecipes = (
+    {
+      username,
+      q,
+      sort
+    }: {
+      username: string
+      q: string
+      sort?: string
+    },
+    opts: RequestInit = {}
+  ) => {
+    const qs = stringify({ username, q, sort })
+    return this._fetch<RecipeSearchDocumentJSON[]>(`/search?${qs}`, opts)
   }
 
   getRecipe = (

--- a/frontend/components/Sort.tsx
+++ b/frontend/components/Sort.tsx
@@ -40,6 +40,7 @@ export const Sort = ({ selected, by, onSort }: SortProps) => (
 const sortBy = (by: SortBy[]) => props => <Sort {...props} by={by} />
 
 export const SortRecipes = sortBy([
+  { name: 'Relevance', value: '' },
   { name: 'Name A-Z', value: 'title-asc' },
   { name: 'Name Z-A', value: 'title-desc' },
   { name: 'Newest', value: 'created_at-desc' },

--- a/frontend/models/index.ts
+++ b/frontend/models/index.ts
@@ -12,6 +12,7 @@ import { Recipe } from './recipe'
 import { RecipeBranch } from './recipe_branch'
 import { RecipeCollaborator } from './recipe_collaborator'
 import { RecipeDuration } from './recipe_duration'
+import { RecipeSearchDocument } from './recipe_search_document'
 import { RecipeVersion } from './recipe_version'
 import { RecipeVersionIngredientList } from './recipe_version_ingredient_list'
 import { RecipeVersionPreheat } from './recipe_version_preheat'
@@ -42,6 +43,7 @@ sequelize.addModels([
   RecipeBranch,
   RecipeCollaborator,
   RecipeDuration,
+  RecipeSearchDocument,
   RecipeVersion,
   RecipeVersionIngredientList,
   RecipeVersionPreheat,
@@ -79,6 +81,7 @@ export * from './recipe'
 export * from './recipe_branch'
 export * from './recipe_collaborator'
 export * from './recipe_duration'
+export * from './recipe_search_document'
 export * from './recipe_version'
 export * from './recipe_version_ingredient_list'
 export * from './recipe_version_procedure_list'

--- a/frontend/models/recipe_search_document.ts
+++ b/frontend/models/recipe_search_document.ts
@@ -1,0 +1,50 @@
+import {
+  PrimaryKey,
+  BelongsTo,
+  Column,
+  ForeignKey,
+  Model,
+  Table
+} from 'sequelize-typescript'
+import { Recipe, RecipeJSON } from './recipe'
+import { User } from './user'
+
+export interface RecipeSearchDocumentJSON {
+  recipe: RecipeJSON
+}
+
+/**
+ * Recipe Search Document
+ *
+ * WARNING: This is not really a table, it is a view! Do not try to insert,
+ * update, or delete records!
+ *
+ * Effectively, this crunches together the recipe's title, description,
+ * ingredients, and procedures and creates a full-text search index which can
+ * be used to find recipes which match a plain text query. See
+ * ../../db/migrate/04_recipe_search.sql for its definition and inner workings.
+ *
+ * This model only exists for nice interoperability with Sequelize, such as
+ * being able to do `findAll` and `include` the Recipe model.
+ */
+@Table({ tableName: 'recipe_search_documents' })
+export class RecipeSearchDocument extends Model<RecipeSearchDocument>
+  implements RecipeSearchDocumentJSON {
+  @PrimaryKey
+  @Column
+  @ForeignKey(() => Recipe)
+  public recipe_id: number
+
+  @Column
+  @ForeignKey(() => User)
+  public user_id: number
+
+  @Column
+  public doc: string
+
+  @BelongsTo(() => Recipe)
+  public recipe: Recipe
+
+  @BelongsTo(() => User)
+  public user: User
+}

--- a/frontend/pages/user.tsx
+++ b/frontend/pages/user.tsx
@@ -34,6 +34,21 @@ interface UserState {
   recipes: RecipeJSON[]
 }
 
+async function getRecipes({
+  username,
+  q,
+  sort
+}: {
+  username: string
+  q?: string
+  sort?: string
+}): Promise<RecipeJSON[]> {
+  if (q) {
+    return _.map(await api.searchUserRecipes({ username, q, sort }), 'recipe')
+  }
+  return await api.getUserRecipes(username, sort)
+}
+
 class User extends React.Component<UserProps & WithRouterProps, UserState> {
   constructor(props: any) {
     super(props)
@@ -54,7 +69,7 @@ class User extends React.Component<UserProps & WithRouterProps, UserState> {
         user: await api.getUser(username),
         query: q,
         sort,
-        recipes: await api.getUserRecipes(username, q, sort)
+        recipes: await getRecipes({ username, q, sort })
       }
     } catch (err) {
       const statusCode = err.statusCode || 500
@@ -81,7 +96,7 @@ class User extends React.Component<UserProps & WithRouterProps, UserState> {
         {
           sort: (sort as string) || '',
           query: (q as string) || '',
-          ...(q ? {} : { recipes: await api.getUserRecipes(username, q, sort) })
+          ...(q ? {} : { recipes: await getRecipes({ username, q, sort }) })
         },
         q || sort ? this.refresh : undefined
       )
@@ -114,9 +129,9 @@ class User extends React.Component<UserProps & WithRouterProps, UserState> {
     const { user } = this.props
     const { query, sort } = this.state
     this.setState({
-      recipes: await api.getUserRecipes(user.username, query, sort)
+      recipes: await getRecipes({ username: user.username, q: query, sort })
     })
-  }, 200)
+  }, 500)
 
   public render() {
     const { user, statusCode } = this.props

--- a/frontend/server/api/search.ts
+++ b/frontend/server/api/search.ts
@@ -1,34 +1,37 @@
 import * as express from 'express'
-import { Recipe } from '../../models/recipe'
-import { internalServerError } from '../errors'
+import * as _ from 'lodash'
+import { Recipe, RecipeSearchDocument, User, sequelize } from '../../models'
+import { internalServerError, badRequest } from '../errors'
+import { validateRecipeSearch } from '../validate'
 const r = express.Router()
 
-export const searchQuery = (q?: string, user_id?: number) => {
-  const or = q
-    ? {
-        $or: {
-          title: {
-            $ilike: `%${q}%`
-          },
-          description: {
-            $ilike: `%${q}%`
-          }
-        }
-      }
-    : {}
-  const user = user_id ? { user_id } : {}
-  return {
-    where: {
-      ...or,
-      ...user
-    }
-  }
-}
-
-r.get('/', async function search(req, res) {
-  const { q, user_id } = req.query
+r.get('/', validateRecipeSearch, async function search(req, res) {
+  const { q, username, sort } = req.query
+  const [col, dir] = _.split(sort, '-')
+  const order =
+    col && dir
+      ? [['recipe', col, _.toUpper(dir)]]
+      : sequelize.literal(
+          `ts_rank(doc, plainto_tsquery(unaccent(${sequelize.escape(q)}))) DESC`
+        )
   try {
-    const results = await Recipe.findAll(searchQuery(q, user_id))
+    const user = await User.findByUsername(username)
+    if (!user) {
+      return badRequest(res, 'user not found')
+    }
+    const results = await RecipeSearchDocument.findAll({
+      where: {
+        [sequelize.Op.and]: [
+          { user_id: user.id },
+          sequelize.literal(
+            `doc @@ plainto_tsquery(unaccent(${sequelize.escape(q)}))`
+          )
+        ]
+      },
+      attributes: [],
+      include: [{ model: Recipe }],
+      order
+    })
     return res.json(results)
   } catch (err) {
     return internalServerError(res, err)

--- a/frontend/server/api/users/user/index.ts
+++ b/frontend/server/api/users/user/index.ts
@@ -1,7 +1,6 @@
 import * as express from 'express'
 import { Request } from 'express'
 import * as _ from 'lodash'
-import { searchQuery } from '../../search'
 import { User, Recipe, sortable } from '../../../../models'
 import { RecipeRequest, recipe } from './recipe'
 import { notFound, internalServerError } from '../../../errors'
@@ -31,15 +30,10 @@ r.get('/', async function getUser(req: UserRequest, res) {
 })
 
 r.get('/recipes', async function getUserRecipes(req: UserRequest, res) {
-  const { q, sort } = req.query
+  const { sort } = req.query
   const order = [RecipeSortBy(_.split(sort, '-') || [])]
   try {
-    return res.json(
-      await Recipe.findAll({
-        ...searchQuery(q, req.user.id),
-        order
-      })
-    )
+    return res.json(await Recipe.findAll({ order }))
   } catch (err) {
     return internalServerError(res, err)
   }

--- a/frontend/server/validate.ts
+++ b/frontend/server/validate.ts
@@ -3,9 +3,15 @@ import { Request, Response } from 'express'
 import * as _ from 'lodash'
 import { HttpStatus } from '../common/http-status'
 
-const validator = schema => {
+const requestBodyGetter = (req: Request) => req.body
+const requestQueryGetter = (req: Request) => req.query
+
+const validator = (schema, objectGetter?: (req: Request) => object) => {
+  if (!objectGetter) {
+    objectGetter = requestBodyGetter
+  }
   return (req: Request, res: Response, next) => {
-    const result = Joi.validate(req.body, schema, {
+    const result = Joi.validate(objectGetter(req), schema, {
       abortEarly: false,
       convert: false,
       allowUnknown: false
@@ -154,3 +160,15 @@ export const validateNotePatch = validator({
   pinned: Joi.boolean(),
   text: Joi.string()
 })
+
+export const validateRecipeSearch = validator(
+  {
+    q: Joi.string().required(),
+    username: Joi.string().required(),
+    sort: Joi.string()
+      .regex(/^(title|created_at)-(asc|desc)$/)
+      .allow('')
+      .optional()
+  },
+  requestQueryGetter
+)


### PR DESCRIPTION
Before, we were using a primitive Postgres ILIKE comparison on the
recipe title and description fields in order to figure out which
recipes were relevant to a search query. This worked decently well, but
it turns out that a common way people want to search their recipes is by
ingredient as well. Rather than implementing an "advanced" search
feature where you can go crazy and select which fields you want to
search for what terms and do a whole bunch of Boolean logic, this patch
adds support for Postgres' built-in full text search indexing.

For background on this method, read the excellent blog post at
http://rachbelaid.com/postgres-full-text-search-is-good-enough/.

There are a few parts to this. First, a view has been added to the
database called recipe_search_documents. This view is designed to
provide a clean interface for running queries and it takes care of
collating the procedures and ingredients of any recipe branch's current
version with the title and description and building a tsvector from
those words (tsvectors are what can be searched over). Effectively, this
searches the recipe's current master branch as that is the only branch
we currently support, though in the future when we expand out to having
multiple branches, the search would also cover other branches. This is
basically just a way to pull in the current version; if we were to
implement better branch support we'd likely want to update the search
functionality to return the specific branch of the recipe that matches,
but that is a problem for the future.

Sequelize doesn't support working with views, so we trick it into
thinking that recipe_search_documents is just a table so that we can do
all the fun sequelize things with it, like including the related recipe
model in the query results.

At the API layer, the ability to add a ?q= query parameter to the
/recipes endpoint has been removed (though they can still be sorted) and
all recipe searches use the previously-implemented-but-hereto-unused
/search endpoint.

The limited UI changes required mostly revolve around knowing when to
use the /recipes and when to use the /search endpoint in order to grab
the list of recipes. The debounce time has been upped from 200ms to
500ms in an effort to run the more-expensive full-text search only when
the user stops typing, and a new "Relevance" option has been added to
the sort order (which, in practice, simply sets the sort to '' as
ranking by relevance doesn't have an associated column and is the
default).

I fully expect we will need to tune a bunch of these things once this is
deployed. Potential performance improvements include using a
materialized view rather than a "regular" view for
recipe_search_documents, and updating the search page to only run the
query once the user hits enter versus searching as-you-type.

The reason this is not yet a materialized view is because that requires
an external refresh process, and would introduce a delay into the recipe
search. For example, if a user adds a recipe for "roasted turnips" and
then immediately searches for "turnip," their newly added recipe would,
confusingly, not appear in the search results until the next time the
materialized view was refreshed. Even refreshing frequently, e.g. every
minute, this might still result in confusing delays. Since the
performance seems to be good enough right now to simply run the full
text search without materializing and indexing the view, we can defer
solving this problem for a little while.

Resolves #233 