### PR TITLE
OCR: Append Text and Rotate Images

### DIFF
--- a/ocr/.gitignore
+++ b/ocr/.gitignore
@@ -4,3 +4,4 @@ build
 recipe.json
 src/recipe.jpg
 src/recipe.pdf
+test.jpg

--- a/ocr/src/utils.ts
+++ b/ocr/src/utils.ts
@@ -39,6 +39,16 @@ export const convert = (dir: string, base: string): Promise<string> => {
   })
 }
 
+export const rotate = (file: string, degrees: string): Promise<any> => {
+  log.info('rotating')
+  return new Promise((resolve, reject) => {
+    log.info('running convert:', `convert ${file} -rotate '${degrees}' ${file}`)
+    exec(`convert '${file}' -rotate '${degrees}' '${file}'`, err =>
+      err ? reject(err) : resolve()
+    )
+  })
+}
+
 // archive recipe in s3
 export const archive = (Key: string) => {
   const id = uuid()


### PR DESCRIPTION
Some quick quality of life improvements for the OCR tool. All text is
now appended instead of replacing. Rotating the image is now supported,
but ugly as heck. But it works. Also dumps the last selected region to
the disk so you can select something easily to be used as an image.