### PR TITLE
Improve procedure parsing

### DIFF
--- a/frontend/components/ProcedureListsEditor.test.ts
+++ b/frontend/components/ProcedureListsEditor.test.ts
@@ -1,0 +1,145 @@
+import { parseProcedureLists } from './ProcedureListsEditor'
+
+describe('parseProcedureLists', () => {
+  it('should work', () => {
+    expect(parseProcedureLists('step 1\nstep 2')).toEqual([
+      {
+        name: undefined,
+        lines: [
+          { text: 'step 1', image_url: undefined, title: undefined },
+          { text: 'step 2', image_url: undefined, title: undefined }
+        ]
+      }
+    ])
+  })
+
+  it('should handle a header before a section', () => {
+    expect(parseProcedureLists('#section\nstep 1')).toEqual([
+      {
+        name: 'section',
+        lines: [{ text: 'step 1', image_url: undefined, title: undefined }]
+      }
+    ])
+  })
+
+  it('should skip blank lines', () => {
+    expect(parseProcedureLists('step1\n\n\n\n\n\nstep2')).toEqual([
+      {
+        name: undefined,
+        lines: [
+          { text: 'step1', image_url: undefined, title: undefined },
+          { text: 'step2', image_url: undefined, title: undefined }
+        ]
+      }
+    ])
+  })
+
+  it('should start a new section when a header is encountered', () => {
+    expect(
+      parseProcedureLists(`
+s1s1
+#new section
+s2s1`)
+    ).toEqual([
+      {
+        name: undefined,
+        lines: [{ text: 's1s1', image_url: undefined, title: undefined }]
+      },
+      {
+        name: 'new section',
+        lines: [{ text: 's2s1', image_url: undefined, title: undefined }]
+      }
+    ])
+  })
+
+  it('should handle images', () => {
+    expect(
+      parseProcedureLists(`
+image:http://example.com/img.jpg
+step1
+image:     http://example.com/i2.jpg       
+image:http://example.com/i3.jpg`)
+    ).toEqual([
+      {
+        name: undefined,
+        lines: [
+          {
+            text: 'step1',
+            image_url: 'http://example.com/img.jpg',
+            title: undefined
+          },
+          {
+            text: undefined,
+            image_url: 'http://example.com/i2.jpg',
+            title: undefined
+          },
+          {
+            text: undefined,
+            image_url: 'http://example.com/i3.jpg',
+            title: undefined
+          }
+        ]
+      }
+    ])
+  })
+
+  it('should handle line breaks', () => {
+    expect(
+      parseProcedureLists(`
+# section 1
+here is a step  
+that spans two lines
+with a second step
+# section 2
+`)
+    ).toEqual([
+      {
+        name: 'section 1',
+        lines: [
+          {
+            text: 'here is a step  \nthat spans two lines',
+            image_url: undefined,
+            title: undefined
+          },
+          {
+            text: 'with a second step',
+            image_url: undefined,
+            title: undefined
+          }
+        ]
+      },
+      {
+        name: 'section 2',
+        lines: []
+      }
+    ])
+  })
+
+  it('should handle tables', () => {
+    expect(
+      parseProcedureLists(`
+# section 1
+here is a step  
+|with|a|table|
+|---|
+|in|it|
+# section 2
+`)
+    ).toEqual([
+      {
+        name: 'section 1',
+        lines: [
+          {
+            text: 'here is a step  \n|with|a|table|\n|---|\n|in|it|',
+            image_url: undefined,
+            title: undefined
+          }
+        ]
+      },
+      {
+        name: 'section 2',
+        lines: []
+      }
+    ])
+  })
+})


### PR DESCRIPTION
Re-introduce support for Markdown features (specifically, line breaks
and tables) that were inadvertently broken when we stopped requiring a
blank line between steps in a0681c275124e2bf9f8c5ac1d2882e2ecf12cb49.

This requires us to be a little smarter and a little more specific than
before. In addition to adding back these broken Markdown features, this
code is generally a little nicer and also has unit tests.

Fixes #300