### PR TITLE
Add user activity tracking

### DIFF
--- a/db/migrate/05_user_activity.sql
+++ b/db/migrate/05_user_activity.sql
@@ -1,0 +1,8 @@
+BEGIN TRANSACTION;
+CREATE TABLE user_activity (
+  date date NOT NULL,
+  user_id integer NOT NULL,
+  UNIQUE(date, user_id)
+);
+ALTER TABLE user_activity ADD FOREIGN KEY (user_id) REFERENCES users (id);
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -135,6 +135,12 @@ CREATE TABLE recipes (
 );
 CREATE UNIQUE INDEX ON recipes (user_id, lower(slug));
 
+CREATE TABLE user_activity (
+  date date NOT NULL,
+  user_id integer NOT NULL,
+  UNIQUE(date, user_id)
+);
+
 CREATE TABLE users (
   id SERIAL PRIMARY KEY,
   username character varying UNIQUE NOT NULL,
@@ -220,3 +226,4 @@ ALTER TABLE recipe_versions ADD FOREIGN KEY (recipe_yield_id) REFERENCES recipe_
 ALTER TABLE recipe_versions ADD FOREIGN KEY (user_id) REFERENCES users (id);
 ALTER TABLE recipes ADD FOREIGN KEY (user_id) REFERENCES users (id);
 ALTER TABLE refresh_tokens ADD FOREIGN KEY (user_id) REFERENCES users (id);
+ALTER TABLE user_activity ADD FOREIGN KEY (user_id) REFERENCES users (id);

--- a/frontend/models/index.ts
+++ b/frontend/models/index.ts
@@ -20,6 +20,7 @@ import { RecipeVersionProcedureList } from './recipe_version_procedure_list'
 import { RecipeYield } from './recipe_yield'
 import { RefreshToken } from './refresh_token'
 import { User } from './user'
+import { UserActivity } from './user_activity'
 import { config } from '../server/config'
 
 export const sequelize = new Sequelize({
@@ -50,7 +51,8 @@ sequelize.addModels([
   RecipeVersionProcedureList,
   RecipeYield,
   RefreshToken,
-  User
+  User,
+  UserActivity
 ])
 
 export const OrderDirections = {
@@ -88,3 +90,4 @@ export * from './recipe_version_procedure_list'
 export * from './recipe_yield'
 export * from './refresh_token'
 export * from './user'
+export * from './user_activity'

--- a/frontend/models/user_activity.ts
+++ b/frontend/models/user_activity.ts
@@ -1,0 +1,30 @@
+import {
+  AllowNull,
+  Column,
+  Model,
+  PrimaryKey,
+  Table
+} from 'sequelize-typescript'
+
+@Table({ tableName: 'user_activity' })
+export class UserActivity extends Model<UserActivity> {
+  @AllowNull(false)
+  @PrimaryKey
+  @Column
+  public date: Date
+
+  @AllowNull(false)
+  @PrimaryKey
+  @Column
+  public user_id: number
+
+  public static async record(user_id: number): Promise<void> {
+    await UserActivity.sequelize.query(
+      'insert into user_activity (date, user_id) values (now()::date, ?) on conflict do nothing',
+      {
+        replacements: [user_id],
+        type: UserActivity.sequelize.QueryTypes.INSERT
+      }
+    )
+  }
+}

--- a/frontend/server/api/index.ts
+++ b/frontend/server/api/index.ts
@@ -3,9 +3,8 @@ import * as _ from 'lodash'
 import * as jwtMiddleware from 'express-jwt'
 import { users } from './users'
 import { user } from './user'
-import { User } from '../../models/user'
+import { RefreshToken, User, UserActivity } from '../../models'
 import { search } from './search'
-import { RefreshToken } from '../../models'
 import { config } from '../config'
 import {
   unauthorized,
@@ -35,6 +34,16 @@ r.use(
     }
   })
 )
+
+r.use(async function recordUserActivity(req, _res, next) {
+  const u = (req as any).user
+  if (u) {
+    try {
+      await UserActivity.record(u.userId)
+    } catch {}
+  }
+  next()
+})
 
 r.use((err, _req, res, next) => {
   if (err && err.name === 'UnauthorizedError') {


### PR DESCRIPTION
Create a new user_activity table which records whether a user was active
on a given day. Each time an authenticated request is made to the API,
we try to insert a row for the user into the user_activity table. Since
we have a unique index on day and user_id, and the INSERT query uses "on
conflict do nothing," the result is simply a row in the table for each
day that a user was active on PlateZero. We can then use this number to
calculate our active user count, for example:

    SELECT count(*) FROM (
      SELECT DISTINCT user_id FROM user_activity
      WHERE date >= now() - '7 days'::interval
    ) AS active_user_ids;