### PR TITLE
Fix Redirect after creating a recipe

### DIFF
--- a/pages/new-recipe-text.tsx
+++ b/pages/new-recipe-text.tsx
@@ -80,11 +80,12 @@ export default class NewRecipe extends React.Component<any, State> {
 
   public async create(event: React.FormEvent<EventTarget>) {
     event.preventDefault()
+    const user = await api.getCurrentUser()
     this.setState({ errors: [] })
     const recipe = this.getRecipe()
     try {
       const res = await api.createRecipe(recipe)
-      Router.push(res.html_url)
+      Router.push(`/${user.username}/${res.slug}`)
     } catch (err) {
       this.setState({ errors: getErrorMessages(err) })
     }
@@ -151,7 +152,7 @@ export default class NewRecipe extends React.Component<any, State> {
             source_title=""
             source_author=""
             source_isbn=""
-            onChange={delta => this.setState(delta)}
+            onChange={(delta) => this.setState(delta)}
           />
           <Button type="submit" color="primary" className="btn-block my-3">
             Create New Recipe!

--- a/pages/new-recipe-url.tsx
+++ b/pages/new-recipe-url.tsx
@@ -129,10 +129,11 @@ export default class ImportURL extends React.Component<any, ImportURLState> {
 
   public async onUrl(e: any, url: string) {
     e.preventDefault()
+    const user = await api.getCurrentUser()
     this.setState({ url })
     try {
       const recipe = await api.importUrl(url)
-      Router.push(recipe.html_url)
+      Router.push(`/${user.username}/${recipe.slug}`)
     } catch (error) {
       if (
         error instanceof PlateZeroApiError &&


### PR DESCRIPTION
Next.js no longer allows routers to push full URL's on router changes.
Instead of using `window.location`, switch to building the route with
the returned slug.

This could be better handled by having the full URL returned by
relative, not absolute.

Resolve #365