### PR TITLE
Remove env vars from config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,26 +2,5 @@ const withSass = require('@zeit/next-sass')
 
 module.exports = (config, { defaultConfig }) => {
   const isProd = process.env.NODE_ENV === 'production'
-  return withSass({
-    env: {
-      cookie: {
-        expires: 365,
-        secure: isProd,
-        samesite: 'strict'
-      }
-    },
-    serverRuntimeConfig: {
-      api: {
-        url: process.env.API_URL
-      }
-    },
-    publicRuntimeConfig: {
-      api: {
-        url: process.env.API_URL
-      },
-      www: {
-        url: process.env.SITE_URL
-      }
-    }
-  })
+  return withSass({})
 }


### PR DESCRIPTION
These will be either removed (if not needed), or re-added in `.env`
files.
